### PR TITLE
Migrating from master-slave language

### DIFF
--- a/pymodmon_cglcd_led_3.py
+++ b/pymodmon_cglcd_led_3.py
@@ -3,7 +3,7 @@
 ## @package pymodmon_CGLCD_LED
 # Python Modbus Monitor for color graphics LCD (CGLCD) and LED output
 # a small program that uses the pymodbus package to retrieve and
-# display modbus slave data.
+# display modbus subordinate data.
 
 # requires: Python >3.7, pymodbus, docopt, pillow, spidev, RPi.GPIO, Adafruit_ILI9341
 #
@@ -902,13 +902,13 @@ class Inout:
 ## class that contains all GUI specifics
 #
 class Gui:
-    def __init__(self,master):
+    def __init__(self,main):
 
         ## configure app window
-        master.title('Python Modbus Monitor LCD')
-        master.minsize(width=550, height=450)
-        master.geometry("550x550")  ## scale window a bit bigger for more data lines
-        self.settingscanvas = tk.Canvas(master,bg="yellow",highlightthickness=0)
+        main.title('Python Modbus Monitor LCD')
+        main.minsize(width=550, height=450)
+        main.geometry("550x550")  ## scale window a bit bigger for more data lines
+        self.settingscanvas = tk.Canvas(main,bg="yellow",highlightthickness=0)
         self.settingscanvas.pack(side='top',anchor='nw',expand=False,fill='x')
 
         ## make the contents of settingscanvas fit the window width
@@ -930,7 +930,7 @@ class Gui:
         controlframe.grid(sticky = 'EW')
 
         ## create Menu
-        menubar = tk.Menu(master)
+        menubar = tk.Menu(main)
         filemenu = tk.Menu(menubar, tearoff=0)
         filemenu.add_command(label='Import Configuration File…',command=self.selectImportFile)
         filemenu.add_command(label='Export Configuration File…',command=self.selectExportFile)
@@ -947,7 +947,7 @@ class Gui:
         menubar.add_cascade(label='File', menu=filemenu)
         menubar.add_cascade(label='Tools', menu=toolmenu)
         menubar.add_cascade(label='Help', menu=helpmenu)
-        master.config(menu=menubar)
+        main.config(menu=menubar)
 
         ## add GUI elements
 
@@ -1028,7 +1028,7 @@ class Gui:
         self.checkManageData.grid(row=3,column=0,columnspan=3)
 
         ## canvas for displaying monitored data
-        self.datacanvas = tk.Canvas(master,bd=1,bg="green",highlightthickness=0)
+        self.datacanvas = tk.Canvas(main,bd=1,bg="green",highlightthickness=0)
         self.datacanvas.pack(anchor='sw',side='top',expand=True,fill='both')
         ## frame that holds all data to display. the static data table and the polled data
         self.dataframe = tk.Frame(self.datacanvas)
@@ -1306,7 +1306,7 @@ class Gui:
     #
     def aboutDialog(self):
         messagebox.showinfo('About Python Modbus Monitor'\
-                 ,'This is a program that acts as a modbus slave to receive data from modbus masters like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
+                 ,'This is a program that acts as a modbus subordinate to receive data from modbus mains like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
 
     ## function for closing the program window
     #

--- a/pymodmon_glcd_led.py
+++ b/pymodmon_glcd_led.py
@@ -3,7 +3,7 @@
 ## @package pymodmon_GLCD_LED
 # Python Modbus Monitor for GLCD and LED output
 # a small program that uses the pymodbus package to retrieve and
-# display modbus slave data.
+# display modbus subordinate data.
 # Can also output to an 128×64 I²C OLED display.
 # requires: Python 2.7, pymodbus, docopt, !!Adafruit_SSD1306??
 #
@@ -790,13 +790,13 @@ class Inout:
 ## class that contains all GUI specifics
 #
 class Gui:
-    def __init__(self,master):
+    def __init__(self,main):
 
         ## configure app window
-        master.title('Python Modbus Monitor LCD')
-        master.minsize(width=550, height=450)
-        master.geometry("550x550")  ## scale window a bit bigger for more data lines
-        self.settingscanvas = Canvas(master,bg="yellow",highlightthickness=0)
+        main.title('Python Modbus Monitor LCD')
+        main.minsize(width=550, height=450)
+        main.geometry("550x550")  ## scale window a bit bigger for more data lines
+        self.settingscanvas = Canvas(main,bg="yellow",highlightthickness=0)
         self.settingscanvas.pack(side='top',anchor='nw',expand=False,fill='x')
 
         ## make the contents of settingscanvas fit the window width
@@ -818,7 +818,7 @@ class Gui:
         controlframe.grid(sticky = 'EW')
 
         ## create Menu
-        menubar = Menu(master)
+        menubar = Menu(main)
         filemenu = Menu(menubar, tearoff=0)
         filemenu.add_command(label='Import Configuration File…',command=self.selectImportFile)
         filemenu.add_command(label='Export Configuration File…',command=self.selectExportFile)
@@ -835,7 +835,7 @@ class Gui:
         menubar.add_cascade(label='File', menu=filemenu)
         menubar.add_cascade(label='Tools', menu=toolmenu)
         menubar.add_cascade(label='Help', menu=helpmenu)
-        master.config(menu=menubar)
+        main.config(menu=menubar)
 
         ## add GUI elements
 
@@ -916,7 +916,7 @@ class Gui:
         self.checkManageData.grid(row=3,column=0,columnspan=3)
 
         ## canvas for displaying monitored data
-        self.datacanvas = Canvas(master,bd=1,bg="green",highlightthickness=0)
+        self.datacanvas = Canvas(main,bd=1,bg="green",highlightthickness=0)
         self.datacanvas.pack(anchor='sw',side='top',expand=True,fill='both')
         ## frame that holds all data to display. the static data table and the polled data
         self.dataframe = Frame(self.datacanvas)
@@ -1194,7 +1194,7 @@ class Gui:
     #
     def aboutDialog(self):
         showinfo('About Python Modbus Monitor'\
-                 ,'This is a program that acts as a modbus slave to receive data from modbus masters like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
+                 ,'This is a program that acts as a modbus subordinate to receive data from modbus mains like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
 
     ## function for closing the program window
     #

--- a/pymodmon_glcd_led_3.py
+++ b/pymodmon_glcd_led_3.py
@@ -3,7 +3,7 @@
 ## @package pymodmon_GLCD_LED
 # Python Modbus Monitor for GLCD and LED output
 # a small program that uses the pymodbus package to retrieve and
-# display modbus slave data.
+# display modbus subordinate data.
 
 # requires: Python 3.7, pymodbus, docopt, spidev, RPi.GPIO, pillow
 #
@@ -801,13 +801,13 @@ class Inout:
 ## class that contains all GUI specifics
 #
 class Gui:
-    def __init__(self,master):
+    def __init__(self,main):
 
         ## configure app window
-        master.title('Python Modbus Monitor LCD')
-        master.minsize(width=550, height=450)
-        master.geometry("550x550")  ## scale window a bit bigger for more data lines
-        self.settingscanvas = tk.Canvas(master,bg="yellow",highlightthickness=0)
+        main.title('Python Modbus Monitor LCD')
+        main.minsize(width=550, height=450)
+        main.geometry("550x550")  ## scale window a bit bigger for more data lines
+        self.settingscanvas = tk.Canvas(main,bg="yellow",highlightthickness=0)
         self.settingscanvas.pack(side='top',anchor='nw',expand=False,fill='x')
 
         ## make the contents of settingscanvas fit the window width
@@ -829,7 +829,7 @@ class Gui:
         controlframe.grid(sticky = 'EW')
 
         ## create Menu
-        menubar = tk.Menu(master)
+        menubar = tk.Menu(main)
         filemenu = tk.Menu(menubar, tearoff=0)
         filemenu.add_command(label='Import Configuration File…',command=self.selectImportFile)
         filemenu.add_command(label='Export Configuration File…',command=self.selectExportFile)
@@ -846,7 +846,7 @@ class Gui:
         menubar.add_cascade(label='File', menu=filemenu)
         menubar.add_cascade(label='Tools', menu=toolmenu)
         menubar.add_cascade(label='Help', menu=helpmenu)
-        master.config(menu=menubar)
+        main.config(menu=menubar)
 
         ## add GUI elements
 
@@ -927,7 +927,7 @@ class Gui:
         self.checkManageData.grid(row=3,column=0,columnspan=3)
 
         ## canvas for displaying monitored data
-        self.datacanvas = tk.Canvas(master,bd=1,bg="green",highlightthickness=0)
+        self.datacanvas = tk.Canvas(main,bd=1,bg="green",highlightthickness=0)
         self.datacanvas.pack(anchor='sw',side='top',expand=True,fill='both')
         ## frame that holds all data to display. the static data table and the polled data
         self.dataframe = tk.Frame(self.datacanvas)
@@ -1205,7 +1205,7 @@ class Gui:
     #
     def aboutDialog(self):
         messagebox.showinfo('About Python Modbus Monitor'\
-                 ,'This is a program that acts as a modbus slave to receive data from modbus masters like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
+                 ,'This is a program that acts as a modbus subordinate to receive data from modbus mains like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
 
     ## function for closing the program window
     #

--- a/pymodmon_lcd.py
+++ b/pymodmon_lcd.py
@@ -3,7 +3,7 @@
 ## @package pymodmon_LCD
 # Python Modbus Monitor for LCD output
 # a small program that uses the pymodbus package to retrieve and
-# display modbus slave data.
+# display modbus subordinate data.
 # requires: Python 2.7, pymodbus, docopt
 #
 # Date created: 2017-06-11
@@ -524,13 +524,13 @@ class Inout:
 ## class that contains all GUI specifics
 #
 class Gui:
-    def __init__(self,master):
+    def __init__(self,main):
 
         ## configure app window
-        master.title('Python Modbus Monitor LCD')
-        master.minsize(width=550, height=450)
-        master.geometry("550x550")  ## scale window a bit bigger for more data lines
-        self.settingscanvas = Canvas(master,bg="yellow",highlightthickness=0)
+        main.title('Python Modbus Monitor LCD')
+        main.minsize(width=550, height=450)
+        main.geometry("550x550")  ## scale window a bit bigger for more data lines
+        self.settingscanvas = Canvas(main,bg="yellow",highlightthickness=0)
         self.settingscanvas.pack(side='top',anchor='nw',expand=False,fill='x')
 
         ## make the contents of settingscanvas fit the window width
@@ -552,7 +552,7 @@ class Gui:
         controlframe.grid(sticky = 'EW')
 
         ## create Menu
-        menubar = Menu(master)
+        menubar = Menu(main)
         filemenu = Menu(menubar, tearoff=0)
         filemenu.add_command(label='Import Configuration File…',command=self.selectImportFile)
         filemenu.add_command(label='Export Configuration File…',command=self.selectExportFile)
@@ -569,7 +569,7 @@ class Gui:
         menubar.add_cascade(label='File', menu=filemenu)
         menubar.add_cascade(label='Tools', menu=toolmenu)
         menubar.add_cascade(label='Help', menu=helpmenu)
-        master.config(menu=menubar)
+        main.config(menu=menubar)
 
         ## add GUI elements
 
@@ -650,7 +650,7 @@ class Gui:
         self.checkManageData.grid(row=3,column=0,columnspan=3)
 
         ## canvas for displaying monitored data
-        self.datacanvas = Canvas(master,bd=1,bg="green",highlightthickness=0)
+        self.datacanvas = Canvas(main,bd=1,bg="green",highlightthickness=0)
         self.datacanvas.pack(anchor='sw',side='top',expand=True,fill='both')
         ## frame that holds all data to display. the static data table and the polled data
         self.dataframe = Frame(self.datacanvas)
@@ -929,7 +929,7 @@ class Gui:
     #
     def aboutDialog(self):
         showinfo('About Python Modbus Monitor'\
-                 ,'This is a program that acts as a modbus slave to receive data from modbus masters like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
+                 ,'This is a program that acts as a modbus subordinate to receive data from modbus mains like SMA solar inverters. \nYou can choose the data to be received via the GUI and see the live data. \nYou can also call the programm from the command line with a configuration file given for the data to be retrieved. \nThe configuration file can be generated using the GUI command \"File\"→\"Export Configuration\"')
         
     ## function for closing the program window
     #


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.